### PR TITLE
Correct parsing of auth serno in case of length is less than 10 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2020-11-27
+### Fixed
+- Correct parsing of auth serno in case of length is less than 10 bytes.
+
+### Changed
+- Some cleanup.
+
 ## [0.1.3] - 2020-07-08
 ### Changed
 - Generated auth serno is fitted to 10 bytes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "extfg-sigma"
 description = "A library for Sigma extfg financial interface messages serialization/deserialization"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Tim Gabets <tim@gabets.ru>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
In case auth_serno is less than 10 bytes, it's trailed with whitespaces. So we need to [handle](https://github.com/timgabets/extfg-sigma/compare/master...fullset:fix_auth_serno_len_less_than_10_bytes?expand=1#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R208) this situation.

Other changes are just little cleaning up.