### PR TITLE
`Error` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2021-02-05
+### Added
+- `Error` type.
+- New methods for `SigmaRequest`/`SigmaResponse` for constructing this types and accessing their fields.
+### Changed
+- Most of the functions/methods now return `Error` instead of logging and returning `0`/`-1`.
+- Renamed some methods of `SigmaRequest`/`SigmaResponse`.
+
 ## [0.1.8] - 2020-12-07
 ### Added
 - Tag 0048 "Additional data" support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2021-02-05
 ### Added
 - `Error` type.
-- New methods for `SigmaRequest`/`SigmaResponse` for constructing this types and accessing their fields.
+- New methods for `SigmaRequest`/`SigmaResponse` for constructing this types and accessing their fields;
+- Ability to store raw byte fields in `iso_fields` and `iso_subfields` of `SigmaRequest`.
 ### Changed
 - Most of the functions/methods now return `Error` instead of logging and returning `0`/`-1`.
 - Renamed some methods of `SigmaRequest`/`SigmaResponse`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "extfg-sigma"
 description = "A library for Sigma extfg financial interface messages serialization/deserialization"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Tim Gabets <tim@gabets.ru>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/timgabets/extfg-sigma"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "0.5.5"
+bytes = "1.0.1"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.23"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,11 @@ pub struct SigmaRequest {
 }
 
 impl SigmaRequest {
-    pub fn new(saf: &str, source: &str, mti: &str, auth_serno: u64) -> Self {
-        Self {
+    pub fn new(saf: &str, source: &str, mti: &str, auth_serno: u64) -> Result<Self, Error> {
+        validate_saf(saf)?;
+        validate_source(source)?;
+        validate_mti(mti)?;
+        Ok(Self {
             saf: saf.into(),
             source: source.into(),
             mti: mti.into(),
@@ -104,14 +107,14 @@ impl SigmaRequest {
             tags: Default::default(),
             iso_fields: Default::default(),
             iso_subfields: Default::default(),
-        }
+        })
     }
 
     pub fn from_json_value(mut data: Value) -> Result<SigmaRequest, Error> {
         let data = data.as_object_mut().ok_or(Error::IncorrectData(
             "SigmaRequest JSON should be object".into(),
         ))?;
-        let mut req = Self::new("N", "X", "0100", 0);
+        let mut req = Self::new("N", "X", "0100", 0)?;
 
         macro_rules! fill_req_field {
             ($fname:ident, $pname:literal, $comment:literal) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,351 +1,302 @@
-use crate::util::{msg_len, serialize_tag, TagType};
-use serde::Serialize;
-use serde_json::Value;
-use std::io;
-
-use bytes::{BufMut, BytesMut};
 use std::collections::BTreeMap;
 
+use bytes::Bytes;
+use bytes::{BufMut, BytesMut};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::util::*;
+
+#[macro_use]
 mod util;
+
+// TODO: validate mandatory fields
+
+#[derive(Debug, thiserror::Error, PartialEq, Clone)]
+pub enum Error {
+    #[error("{0}")]
+    Bounds(String),
+    #[error("Incorrect tag: {0}")]
+    IncorrectTag(String),
+    #[error("Incorrect field '{field_name}', should be {should_be}")]
+    IncorrectFieldData {
+        field_name: String,
+        should_be: String,
+    },
+    #[error("Missing field '{0}'")]
+    MissingField(String),
+    #[error("{0}")]
+    IncorrectData(String),
+}
+
+impl Error {
+    fn incorrect_field_data(field_name: &str, should_be: &str) -> Self {
+        Self::IncorrectFieldData {
+            field_name: field_name.into(),
+            should_be: should_be.into(),
+        }
+    }
+}
 
 #[derive(Serialize, Debug)]
 pub struct SigmaRequest {
-    saf: String,
-    source: String,
-    mti: String,
-    auth_serno: u64,
-    tags: BTreeMap<usize, String>,
-    iso_fields: BTreeMap<usize, String>,
+    pub saf: String,
+    pub source: String,
+    pub mti: String,
+    pub auth_serno: u64,
+    pub tags: BTreeMap<u16, String>,
+    pub iso_fields: BTreeMap<u16, String>,
+    pub iso_subfields: BTreeMap<(u16, u8), String>,
 }
 
 impl SigmaRequest {
-    pub fn new(data: Value) -> Result<SigmaRequest, io::ErrorKind> {
-        let mut req = SigmaRequest {
-            saf: String::from("N"),
-            source: String::from("X"),
-            mti: String::from("0100"),
-            auth_serno: 0,
-            tags: BTreeMap::new(),
-            iso_fields: BTreeMap::new(),
-        };
+    pub fn new(saf: &str, source: &str, mti: &str, auth_serno: u64) -> Self {
+        Self {
+            saf: saf.into(),
+            source: source.into(),
+            mti: mti.into(),
+            auth_serno,
+            tags: Default::default(),
+            iso_fields: Default::default(),
+            iso_subfields: Default::default(),
+        }
+    }
 
-        // SAF
-        let mut f = "SAF";
-        match data.get(f) {
-            Some(opt) => {
-                match opt.as_str() {
-                    Some(v) => {
-                        req.saf = v.to_string();
-                    }
+    pub fn from_json_value(mut data: Value) -> Result<SigmaRequest, Error> {
+        let data = data.as_object_mut().ok_or(Error::IncorrectData(
+            "SigmaRequest JSON should be object".into(),
+        ))?;
+        let mut req = Self::new("N", "X", "0100", 0);
+
+        macro_rules! fill_req_field {
+            ($fname:ident, $pname:literal, $comment:literal) => {
+                match data.remove($pname) {
+                    Some(x) => match x.as_str() {
+                        Some(v) => {
+                            req.$fname = v.to_string();
+                        }
+                        None => {
+                            return Err(Error::IncorrectFieldData {
+                                field_name: $pname.to_string(),
+                                should_be: $comment.to_string(),
+                            });
+                        }
+                    },
                     None => {
-                        println!("Incoming request has invalid {} field data format - should be a String", f);
-                        return Err(io::ErrorKind::InvalidData);
+                        return Err(Error::MissingField($pname.to_string()));
                     }
                 }
-            }
-            None => {
-                println!("Incoming request has missing mandatory {} field", f);
-                return Err(io::ErrorKind::InvalidInput);
-            }
+            };
         }
 
-        // Source
-        f = "SRC";
-        match data.get(f) {
-            Some(opt) => {
-                match opt.as_str() {
-                    Some(v) => {
-                        req.source = v.to_string();
-                    }
-                    None => {
-                        println!("Incoming request has invalid {} field data format - should be a String", f);
-                        return Err(io::ErrorKind::InvalidData);
-                    }
-                }
-            }
-            None => {
-                println!("Incoming request has missing mandatory {} field", f);
-                return Err(io::ErrorKind::InvalidInput);
-            }
-        }
-
-        // Source
-        f = "MTI";
-        match data.get(f) {
-            Some(opt) => {
-                match opt.as_str() {
-                    Some(v) => {
-                        req.mti = v.to_string();
-                    }
-                    None => {
-                        println!("Incoming request has invalid {} field data format - should be a String", f);
-                        return Err(io::ErrorKind::InvalidData);
-                    }
-                }
-            }
-            None => {
-                println!("Incoming request has missing mandatory {} field", f);
-                return Err(io::ErrorKind::InvalidInput);
-            }
-        }
-
+        fill_req_field!(saf, "SAF", "String");
+        fill_req_field!(source, "SRC", "String");
+        fill_req_field!(mti, "MTI", "String");
         // Authorization serno
-        f = "Serno";
-        match data.get(f) {
-            Some(opt) => match opt.as_str() {
-                Some(v) => {
-                    req.auth_serno = v.parse::<u64>().unwrap();
+        match data.remove("Serno") {
+            Some(x) => {
+                if let Some(s) = x.as_str() {
+                    req.auth_serno = s.parse::<u64>().map_err(|_| Error::IncorrectFieldData {
+                        field_name: "Serno".into(),
+                        should_be: "integer".into(),
+                    })?;
+                } else if let Some(v) = x.as_u64() {
+                    req.auth_serno = v;
+                } else {
+                    return Err(Error::IncorrectFieldData {
+                        field_name: "Serno".into(),
+                        should_be: "u64 or String with integer".into(),
+                    });
                 }
-                None => {
-                    // Not a string
-                    match opt.as_u64() {
-                        Some(v) => {
-                            req.auth_serno = v;
-                        }
-                        None => {
-                            // Neither a string nor a u64
-                            println!(
-                                "Incoming request has invalid {} field data format - should be u64 ot string",
-                                f
-                            );
-                            return Err(io::ErrorKind::InvalidData);
-                        }
-                    }
-                }
-            },
+            }
             None => {
-                req.auth_serno = util::gen_auth_serno();
+                req.auth_serno = util::gen_random_auth_serno();
             }
         }
 
-        // Tags
-        for i in 0..23 {
-            let id = format!("T{:04}", i);
-            if let Some(tag) = data.get(id) {
-                match tag.as_str() {
-                    Some(v) => {
-                        req.tags.insert(i, v.to_string());
-                    }
-                    None => match tag.as_u64() {
-                        Some(v) => {
-                            req.tags.insert(i, v.to_string());
-                        }
-                        None => {
-                            println!("Incoming request has invalid {} field data format - should be either String or u64", format!("T{:04}", i));
-                            return Err(io::ErrorKind::InvalidData);
-                        }
-                    },
-                }
-            }
-        }
-
-        // ISO Fields
-        for i in 0..128 {
-            let id = format!("i{:03}", i);
-            if let Some(tag) = data.get(id) {
-                match tag.as_str() {
-                    Some(v) => {
-                        req.iso_fields.insert(i, v.to_string());
-                    }
-                    None => match tag.as_u64() {
-                        Some(v) => {
-                            req.iso_fields.insert(i, v.to_string());
-                        }
-                        None => {
-                            println!("Incoming request has invalid {} field data format - should be either String or u64", format!("i{:03}", i));
-                            return Err(io::ErrorKind::InvalidData);
-                        }
-                    },
-                }
-            }
+        for (name, field_data) in data.iter() {
+            let tag = Tag::from_str(&name)?;
+            let content = if let Some(x) = field_data.as_str() {
+                x.into()
+            } else if let Some(x) = field_data.as_u64() {
+                format!("{}", x)
+            } else {
+                return Err(Error::IncorrectFieldData {
+                    field_name: name.clone(),
+                    should_be: "u64 or String with integer".into(),
+                });
+            };
+            match tag {
+                Tag::Regular(i) => req.tags.insert(i, content),
+                Tag::Iso(i) => req.iso_fields.insert(i, content),
+                Tag::IsoSubfield(i, si) => req.iso_subfields.insert((i, si), content),
+            };
         }
 
         Ok(req)
     }
 
-    pub fn serialize(&self) -> Result<BytesMut, String> {
+    // TODO: access to fields
+
+    pub fn encode(&self) -> Result<Bytes, Error> {
         let mut buf = BytesMut::with_capacity(8192);
         buf.put(self.saf.as_bytes());
         buf.put(self.source.as_bytes());
         buf.put(self.mti.as_bytes());
-        let mut auth_serno = self.auth_serno.to_string();
-        if auth_serno.len() > 10 {
-            auth_serno.truncate(10);
+        if self.auth_serno > 9999999999 {
+            buf.put(&format!("{}", self.auth_serno).as_bytes()[0..10]);
         } else {
-            auth_serno = format!("{:010}", auth_serno);
+            buf.put(format!("{:010}", self.auth_serno).as_bytes());
         }
 
-        buf.put(auth_serno.as_bytes());
-
-        for key in self.tags.keys() {
-            buf.put(serialize_tag(
-                TagType::Regular,
-                *key,
-                self.tags[key].as_str(),
-            ));
+        for (k, v) in self.tags.iter() {
+            encode_field_to_buf(Tag::Regular(*k), &v, &mut buf)?;
         }
 
-        for key in self.iso_fields.keys() {
-            buf.put(serialize_tag(
-                TagType::Iso,
-                *key,
-                self.iso_fields[key].as_str(),
-            ));
+        for (k, v) in self.iso_fields.iter() {
+            encode_field_to_buf(Tag::Iso(*k), &v, &mut buf)?;
         }
 
-        // Appending message length
-        let mut serialized = BytesMut::with_capacity(8192);
-        serialized.put(msg_len(buf.len()));
-        serialized.put(buf);
+        for ((k, k1), v) in self.iso_subfields.iter() {
+            encode_field_to_buf(Tag::IsoSubfield(*k, *k1), &v, &mut buf)?;
+        }
 
-        Ok(serialized.split())
+        let mut buf_res = BytesMut::with_capacity(buf.len() + 10);
+        buf_res.put(format!("{:05}", buf.len()).as_bytes());
+        buf_res.put(buf);
+
+        Ok(buf_res.into())
     }
 }
 
 #[derive(Serialize, Debug)]
 pub struct FeeData {
-    reason: i32,
-    currency: i32,
-    amount: i64,
+    pub reason: u16,
+    pub currency: u16,
+    pub amount: u64,
 }
 
 impl FeeData {
-    pub fn new(data: &[u8], data_len: usize) -> Self {
-        let mut reason = -1;
-        let mut currency = -1;
-        let mut amount = -1;
-
-        if data_len >= 8 {
+    pub fn from_slice(data: &[u8]) -> Result<Self, Error> {
+        if data.len() >= 8 {
             // "\x00\x32\x00\x00\x108116978300"
-            reason = match String::from_utf8_lossy(&data[0..4]).parse() {
-                Ok(r) => r,
-                Err(_) => -1,
-            };
-
-            currency = match String::from_utf8_lossy(&data[4..7]).parse() {
-                Ok(r) => r,
-                Err(_) => -1,
-            };
-
-            amount = match String::from_utf8_lossy(&data[7..data_len]).parse() {
-                Ok(r) => r,
-                Err(_) => -1,
-            };
+            let reason = parse_ascii_bytes!(
+                &data[0..4],
+                u16,
+                Error::incorrect_field_data("FeeData.reason", "valid integer")
+            )?;
+            let currency = parse_ascii_bytes!(
+                &data[4..7],
+                u16,
+                Error::incorrect_field_data("FeeData.currency", "valid integer")
+            )?;
+            let amount = parse_ascii_bytes!(
+                &data[7..],
+                u64,
+                Error::incorrect_field_data("FeeData.amount", "valid integer")
+            )?;
+            Ok(Self {
+                reason,
+                currency,
+                amount,
+            })
         } else {
-            println!("FeeData length error: {:?}", data_len);
-        };
-
-        FeeData {
-            reason,
-            currency,
-            amount,
+            Err(Error::IncorrectData(
+                "FeeData slice should be longer than 8 bytes".into(),
+            ))
         }
     }
 }
 
 #[derive(Serialize, Debug)]
 pub struct SigmaResponse {
-    mti: String,
-    auth_serno: i64,
-    reason: i32,
+    pub mti: String,
+    pub auth_serno: u64,
+    pub reason: u32,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    fees: Vec<FeeData>,
-    #[serde(skip_serializing_if = "String::is_empty")]
-    adata: String,
+    pub fees: Vec<FeeData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adata: Option<String>,
+}
+
+fn bytes_split_to(bytes: &mut Bytes, at: usize) -> Result<Bytes, Error> {
+    let len = bytes.len();
+
+    if len < at {
+        return Err(Error::Bounds(format!(
+            "split_to out of bounds: {:?} <= {:?}",
+            at,
+            bytes.len(),
+        )));
+    }
+
+    Ok(bytes.split_to(at))
 }
 
 impl SigmaResponse {
-    pub fn new(s: &[u8]) -> Self {
-        let mut fees = Vec::new();
-        let mut reason = -1;
-        let mut adata = String::new();
-
-        let mut from: usize = 0;
-        let mut to: usize = 5;
-        let msg_data_len = match String::from_utf8_lossy(&s[from..to]).parse::<usize>() {
-            Ok(r) => r + 5,
-            Err(_) => 0,
-        };
-
-        from = 5;
-        to = 9;
-        if msg_data_len < from || msg_data_len < from {
-            println!(
-                "Out of boundaries error: data length is {:?}, but trying to access [{:?}..{:?}]",
-                msg_data_len, from, to
-            );
-            // TODO: exit or something
+    pub fn new(mti: &str, auth_serno: u64, reason: u32) -> Self {
+        Self {
+            mti: mti.into(),
+            auth_serno,
+            reason,
+            fees: Vec::new(),
+            adata: Option::None,
         }
+    }
 
-        let mti = String::from_utf8_lossy(&s[from..to]).to_string();
+    pub fn decode(mut data: Bytes) -> Result<Self, Error> {
+        let mut resp = Self::new("0100", 0, 0);
 
-        from = 9;
-        to = from + 10;
-        if msg_data_len < from || msg_data_len < from {
-            println!(
-                "Out of boundaries error: data length is {:?}, but trying to access [{:?}..{:?}]",
-                msg_data_len, from, to
-            );
-            // TODO: exit or something
-        }
-        let auth_serno = match String::from_utf8_lossy(&s[from..to])
-            .split_whitespace()
-            .map(|s| s.parse::<i64>())
-            .next()
-        {
-            Some(Ok(r)) => r,
-            Some(Err(_)) => -1,
-            None => -1,
-        };
+        let msg_len = parse_ascii_bytes!(
+            &bytes_split_to(&mut data, 5)?,
+            usize,
+            Error::incorrect_field_data("message length", "valid integer")
+        )?;
+        let mut data = bytes_split_to(&mut data, msg_len)?;
 
-        let mut cursor = to;
-        while (cursor + 1) < msg_data_len {
+        resp.mti = String::from_utf8_lossy(&bytes_split_to(&mut data, 4)?).to_string();
+        resp.auth_serno = String::from_utf8_lossy(&bytes_split_to(&mut data, 10)?)
+            .trim()
+            .parse::<u64>()
+            .map_err(|_| Error::IncorrectFieldData {
+                field_name: "Serno".into(),
+                should_be: "u64".into(),
+            })?;
+
+        while !data.is_empty() {
             /*
-             *  cursor
              *  |
              *  |  T  | \x00 | \x31 | \x00 | \x00 | \x04 |  8  |  1  |  0  |  0  |
              *        |             |      |             |                       |
              *        |__ tag id ___|      |tag data len |_______ data __________|
              */
-            let tag_id_start = cursor + 1;
-            let tag_id_end = tag_id_start + 2;
+            let tag_src = bytes_split_to(&mut data, 4)?;
+            let tag = Tag::decode(tag_src)?;
 
-            let tag_id: u16 = util::bcd2u16(&s[tag_id_start..]);
+            let len_src = bytes_split_to(&mut data, 2)?;
+            let len = decode_bcd_x4(&[len_src[0], len_src[1]])?;
 
-            let tag_data_len = util::bcd2u16(&s[tag_id_end + 1..]);
-            let tag_data_start = tag_id_end + 1 + 2;
-            let tag_data_end = tag_data_start + tag_data_len as usize;
-            cursor = tag_data_end;
+            let data_src = bytes_split_to(&mut data, len as usize)?;
 
-            if tag_id == 31 {
-                reason = match String::from_utf8_lossy(&s[tag_data_start..tag_data_end]).parse() {
-                    Ok(r) => r,
-                    Err(_) => -1,
-                };
-            }
-
-            if tag_id == 32 {
-                let fee = FeeData::new(&s[tag_data_start..tag_data_end], tag_data_len as usize);
-                fees.push(fee)
-            }
-
-            if tag_id == 48 {
-                adata = String::from_utf8_lossy(&s[tag_data_start..tag_data_end]).to_string();
+            match tag {
+                Tag::Regular(31) => {
+                    resp.reason = parse_ascii_bytes!(
+                        &data_src,
+                        u32,
+                        Error::incorrect_field_data("reason", "shloud be u32")
+                    )?;
+                }
+                Tag::Regular(32) => {
+                    resp.fees.push(FeeData::from_slice(&data_src)?);
+                }
+                Tag::Regular(48) => {
+                    resp.adata = Some(String::from_utf8_lossy(&data_src).to_string());
+                }
+                _ => {}
             }
         }
 
-        SigmaResponse {
-            mti,
-            auth_serno,
-            reason,
-            fees,
-            adata,
-        }
-    }
-
-    pub fn serialize(&self) -> Result<String, serde_json::error::Error> {
-        let serialized = serde_json::to_string(&self)?;
-        Ok(serialized)
+        Ok(resp)
     }
 }
 
@@ -401,7 +352,8 @@ mod tests {
             "i102": 2371492071643
         }"#;
 
-        let r: SigmaRequest = SigmaRequest::new(serde_json::from_str(&payload).unwrap()).unwrap();
+        let r: SigmaRequest =
+            SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).unwrap();
         assert_eq!(r.saf, "Y");
         assert_eq!(r.source, "M");
         assert_eq!(r.mti, "0200");
@@ -521,7 +473,8 @@ mod tests {
             "i102": 2371492071643
         }"#;
 
-        let r: SigmaRequest = SigmaRequest::new(serde_json::from_str(&payload).unwrap()).unwrap();
+        let r: SigmaRequest =
+            SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).unwrap();
         assert_eq!(r.saf, "Y");
         assert_eq!(r.source, "M");
         assert_eq!(r.mti, "0200");
@@ -600,7 +553,7 @@ mod tests {
             "MTI": "0200"
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if mandatory field is missing");
         }
     }
@@ -613,7 +566,7 @@ mod tests {
             "MTI": "0200"
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if the filed has invalid format");
         }
     }
@@ -625,7 +578,7 @@ mod tests {
             "MTI": "0200"
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if mandatory field is missing");
         }
     }
@@ -638,7 +591,7 @@ mod tests {
             "MTI": "0200"
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if the filed has invalid format");
         }
     }
@@ -650,7 +603,7 @@ mod tests {
         	"SRC": "O"
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if mandatory field is missing");
         }
     }
@@ -663,7 +616,7 @@ mod tests {
             "MTI": 1200
         }"#;
 
-        if SigmaRequest::new(serde_json::from_str(&payload).unwrap()).is_ok() {
+        if SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).is_ok() {
             unreachable!("Should not return Ok if the filed has invalid format");
         }
     }
@@ -677,7 +630,8 @@ mod tests {
                 "T0000": "02371492071643"
             }"#;
 
-        let r: SigmaRequest = SigmaRequest::new(serde_json::from_str(&payload).unwrap()).unwrap();
+        let r: SigmaRequest =
+            SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).unwrap();
         assert!(
             r.auth_serno > 0,
             "Should generate authorization serno if the field is missing"
@@ -693,8 +647,9 @@ mod tests {
                 "Serno": 7877706965687192023
             }"#;
 
-        let r: SigmaRequest = SigmaRequest::new(serde_json::from_str(&payload).unwrap()).unwrap();
-        let serialized = r.serialize().unwrap();
+        let r: SigmaRequest =
+            SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).unwrap();
+        let serialized = r.encode().unwrap();
         assert_eq!(
             serialized,
             b"00016YM02017877706965"[..],
@@ -750,8 +705,9 @@ mod tests {
                 "i102": 2371492071643
             }"#;
 
-        let r: SigmaRequest = SigmaRequest::new(serde_json::from_str(&payload).unwrap()).unwrap();
-        let serialized = r.serialize().unwrap();
+        let r: SigmaRequest =
+            SigmaRequest::from_json_value(serde_json::from_str(&payload).unwrap()).unwrap();
+        let serialized = r.encode().unwrap();
         assert_eq!(
             serialized,
             b"00536YM02006007040979T\x00\x00\x00\x00\x132371492071643T\x00\x01\x00\x00\x01CT\x00\x02\x00\x00\x03643T\x00\x03\x00\x00\x12000100000000T\x00\x04\x00\x00\x03978T\x00\x05\x00\x00\x12000300000000T\x00\x06\x00\x00\x04OPS6T\x00\x07\x00\x00\x0219T\x00\x08\x00\x00\x03643T\x00\t\x00\x00\x043102T\x00\x10\x00\x00\x043104T\x00\x11\x00\x00\x012T\x00\x14\x00\x00\x10IDDQD BankT\x00\x16\x00\x00\x0874707182T\x00\x18\x00\x00\x01YT\x00\x22\x00\x00\x12000000000010I\x00\x00\x00\x00\x040100I\x00\x02\x00\x00\x16555544******1111I\x00\x03\x00\x00\x06500000I\x00\x04\x00\x00\x12000100000000I\x00\x06\x00\x00\x12000100000000I\x00\x07\x00\x00\x100629151748I\x00\x11\x00\x00\x06100250I\x00\x12\x00\x00\x06181748I\x00\x13\x00\x00\x040629I\x00\x18\x00\x00\x040000I\x00\"\x00\x00\x040000I\x00%\x00\x00\x0202I\x002\x00\x00\x06010455I\x007\x00\x00\x12002595100250I\x00A\x00\x00\x03990I\x00B\x00\x00\x04DCZ1I\x00C\x00\x008IDDQD Bank.                         GEI\x00H\x00\x00\x16USRDT|2595100250I\x00I\x00\x00\x03643I\x00Q\x00\x00\x03643I\x00`\x00\x00\x013I\x01\x01\x00\x00\x0891926242I\x01\x02\x00\x00\x132371492071643"[..]
@@ -759,15 +715,15 @@ mod tests {
     }
 
     #[test]
-    fn sigma_response_new() {
-        let s = b"0002501104007040978T\x00\x31\x00\x00\x048495";
+    fn sigma_response_decode() {
+        let s = Bytes::from_static(b"0002401104007040978T\x00\x31\x00\x00\x048495");
 
-        let resp = SigmaResponse::new(s);
+        let resp = SigmaResponse::decode(s).unwrap();
         assert_eq!(resp.mti, "0110");
         assert_eq!(resp.auth_serno, 4007040978);
         assert_eq!(resp.reason, 8495);
 
-        let serialized = resp.serialize().unwrap();
+        let serialized = serde_json::to_string(&resp).unwrap();
         assert_eq!(
             serialized,
             r#"{"mti":"0110","auth_serno":4007040978,"reason":8495}"#
@@ -776,46 +732,30 @@ mod tests {
 
     #[test]
     fn sigma_response_incorrect_auth_serno() {
-        let s = b"000250110XYZ7040978T\x00\x31\x00\x00\x048100";
+        let s = Bytes::from_static(b"000250110XYZ7040978T\x00\x31\x00\x00\x048100");
 
-        let resp = SigmaResponse::new(s);
-        assert_eq!(resp.mti, "0110");
-        assert_eq!(resp.auth_serno, -1);
-        assert_eq!(resp.reason, 8100);
-
-        let serialized = resp.serialize().unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"mti":"0110","auth_serno":-1,"reason":8100}"#
-        );
+        assert!(SigmaResponse::decode(s).is_err());
     }
 
     #[test]
     fn sigma_response_incorrect_reason() {
-        let s = b"0002501104007040978T\x00\x31\x00\x00\x04ABCD";
+        let s = Bytes::from_static(b"0002501104007040978T\x00\x31\x00\x00\x04ABCD");
 
-        let resp = SigmaResponse::new(s);
-        assert_eq!(resp.mti, "0110");
-        assert_eq!(resp.auth_serno, 4007040978);
-        assert_eq!(resp.reason, -1);
-
-        let serialized = resp.serialize().unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"mti":"0110","auth_serno":4007040978,"reason":-1}"#
-        );
+        assert!(SigmaResponse::decode(s).is_err());
     }
 
     #[test]
     fn sigma_response_fee_data() {
-        let s = b"0004001104007040978T\x00\x31\x00\x00\x048100T\x00\x32\x00\x00\x108116978300";
+        let s = Bytes::from_static(
+            b"0004001104007040978T\x00\x31\x00\x00\x048100T\x00\x32\x00\x00\x108116978300",
+        );
 
-        let resp = SigmaResponse::new(s);
+        let resp = SigmaResponse::decode(s).unwrap();
         assert_eq!(resp.mti, "0110");
         assert_eq!(resp.auth_serno, 4007040978);
         assert_eq!(resp.reason, 8100);
 
-        let serialized = resp.serialize().unwrap();
+        let serialized = serde_json::to_string(&resp).unwrap();
         assert_eq!(
             serialized,
             r#"{"mti":"0110","auth_serno":4007040978,"reason":8100,"fees":[{"reason":8116,"currency":978,"amount":300}]}"#
@@ -824,14 +764,14 @@ mod tests {
 
     #[test]
     fn sigma_response_correct_short_auth_serno() {
-        let s = b"000240110123123    T\x00\x31\x00\x00\x048100";
+        let s = Bytes::from_static(b"000240110123123    T\x00\x31\x00\x00\x048100");
 
-        let resp = SigmaResponse::new(s);
+        let resp = SigmaResponse::decode(s).unwrap();
         assert_eq!(resp.mti, "0110");
         assert_eq!(resp.auth_serno, 123123);
         assert_eq!(resp.reason, 8100);
 
-        let serialized = resp.serialize().unwrap();
+        let serialized = serde_json::to_string(&resp).unwrap();
         assert_eq!(
             serialized,
             r#"{"mti":"0110","auth_serno":123123,"reason":8100}"#
@@ -842,7 +782,7 @@ mod tests {
     fn fee_data() {
         let data = b"8116978300";
 
-        let fee = FeeData::new(data, 10);
+        let fee = FeeData::from_slice(data).unwrap();
         assert_eq!(fee.reason, 8116);
         assert_eq!(fee.currency, 978);
         assert_eq!(fee.amount, 300);
@@ -852,7 +792,7 @@ mod tests {
     fn fee_data_large_amount() {
         let data = b"8116643123456789";
 
-        let fee = FeeData::new(data, 16);
+        let fee = FeeData::from_slice(data).unwrap();
         assert_eq!(fee.reason, 8116);
         assert_eq!(fee.currency, 643);
         assert_eq!(fee.amount, 123456789);
@@ -860,14 +800,14 @@ mod tests {
 
     #[test]
     fn sigma_response_fee_data_additional_data() {
-        let s = b"0015201104007040978T\x00\x31\x00\x00\x048100T\x00\x32\x00\x00\x1181166439000T\x00\x48\x00\x01\x05CJyuARCDBRibpKn+BSIVCgx0ZmE6FwAAAKoXmwIQnK4BGLcBIhEKDHRmcDoWAAAAxxX+ARik\nATCBu4PdBToICKqv7BQQgwVAnK4BSAI=";
+        let s = Bytes::from_static(b"0015201104007040978T\x00\x31\x00\x00\x048100T\x00\x32\x00\x00\x1181166439000T\x00\x48\x00\x01\x05CJyuARCDBRibpKn+BSIVCgx0ZmE6FwAAAKoXmwIQnK4BGLcBIhEKDHRmcDoWAAAAxxX+ARik\nATCBu4PdBToICKqv7BQQgwVAnK4BSAI=");
 
-        let resp = SigmaResponse::new(s);
+        let resp = SigmaResponse::decode(s).unwrap();
         assert_eq!(resp.mti, "0110");
         assert_eq!(resp.auth_serno, 4007040978);
         assert_eq!(resp.reason, 8100);
 
-        let serialized = resp.serialize().unwrap();
+        let serialized = serde_json::to_string(&resp).unwrap();
         assert_eq!(
             serialized,
             r#"{"mti":"0110","auth_serno":4007040978,"reason":8100,"fees":[{"reason":8116,"currency":643,"amount":9000}],"adata":"CJyuARCDBRibpKn+BSIVCgx0ZmE6FwAAAKoXmwIQnK4BGLcBIhEKDHRmcDoWAAAAxxX+ARik\nATCBu4PdBToICKqv7BQQgwVAnK4BSAI="}"#

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,226 +1,322 @@
-extern crate rand;
-
-use bytes::{BufMut, BytesMut};
+use bytes::BufMut;
+use bytes::Bytes;
 use rand::Rng;
-use std::convert::TryInto;
+
+use super::Error;
+
+macro_rules! parse_ascii_bytes {
+    ($b:expr, $t:ty, $err:expr) => {
+        String::from_utf8_lossy($b).parse::<$t>().map_err(|_| $err)
+    };
+}
 
 /// Generate Authorization Serno
-pub fn gen_auth_serno() -> u64 {
+pub fn gen_random_auth_serno() -> u64 {
     let mut rng = rand::thread_rng();
     let rrn: u64 = rng.gen();
     rrn
 }
 
-fn pop(x: &[u8]) -> &[u8; 2] {
-    x.try_into().expect("slice with incorrect length")
-}
-
-#[rustfmt::skip]
-/// Convert two-byte BCD representation to u16
-pub fn bcd2u16(x: &[u8]) -> u16 {
-    let bcd_table = [
-         0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 0, 0, 0, 0, 0, 0,
-        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 0, 0, 0, 0, 0,
-        20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 0, 0, 0, 0, 0, 0,
-        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 0, 0, 0, 0, 0, 0,
-        40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 0, 0, 0, 0, 0, 0,
-        50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 0, 0, 0, 0, 0, 0,
-        60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 0, 0, 0, 0, 0, 0,
-        70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 0, 0, 0, 0, 0, 0,
-        80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 0, 0, 0, 0, 0, 0,
-        90, 91, 92, 93, 94, 95, 96, 97, 98, 99
-    ];
-    let index: usize = u16::from_be_bytes(*pop(&x[0..2])) as usize;
-    if index < bcd_table.len() {
-        /* Values less than 0x99 */
-        return bcd_table[index];
-    } else if index >= 0x100 {
-        let msb : usize = (index/0x100) as usize;
-        let lsb = index % 0x100;
-        return bcd_table[msb] * 100 + bcd_table[lsb];
+pub(crate) fn decode_bcd_x2(v: u8) -> Result<u8, Error> {
+    let left = v >> 4;
+    if !matches!(left, 0..=9) {
+        return Err(Error::Bounds(format!(
+            "Left bits is not in [0,9] range: {:X}",
+            v
+        )));
     }
-    0
-}
 
-#[rustfmt::skip]
-fn dec2bcd(dec: usize) -> i32 {
-    // As for now (July 2020) there is no stable BCD library in Rust, and I would not like to implement the one.
-    // Convertion table is quite enough for now.
-    let bcd_table = [
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
-        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
-        0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
-        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
-        0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
-        0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59,
-        0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
-        0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
-        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
-        0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99,
-        0x100, 0x101, 0x102, 0x103, 0x104, 0x105, 0x106, 0x107, 0x108, 0x109,
-        0x110, 0x111, 0x112, 0x113, 0x114, 0x115, 0x116, 0x117, 0x118, 0x119,
-        0x120, 0x121, 0x122, 0x123, 0x124, 0x125, 0x126, 0x127, 0x128,
-    ];
-    if dec < bcd_table.len() {
-        return bcd_table[dec];
+    let right = v & 0x0f;
+    if !matches!(right, 0..=9) {
+        return Err(Error::Bounds(format!(
+            "Right bits is not in [0,9] range: {:X}",
+            v
+        )));
     }
-    -1
+
+    Ok(left * 10 + right)
 }
 
-pub fn msg_len(len: usize) -> BytesMut {
-    let mut buf = BytesMut::with_capacity(64);
-    buf.put_u8(((len % 100000) / 10000) as u8 + 0x30);
-    buf.put_u8(((len % 10000) / 1000) as u8 + 0x30);
-    buf.put_u8(((len % 1000) / 100) as u8 + 0x30);
-    buf.put_u8(((len % 100) / 10) as u8 + 0x30);
-    buf.put_u8((len % 10) as u8 + 0x30);
-
-    buf.split()
+pub(crate) fn decode_bcd_x4(v: &[u8; 2]) -> Result<u16, Error> {
+    let l = decode_bcd_x2(v[0])?;
+    let r = decode_bcd_x2(v[1])?;
+    Ok(l as u16 * 100 + r as u16)
 }
 
-pub enum TagType {
-    Regular,
-    Iso,
+pub(crate) fn encode_bcd_x2(v: u8) -> Result<u8, Error> {
+    if v > 99 {
+        return Err(Error::Bounds(format!(
+            "u8 '{}' contains more than 2 digits",
+            v
+        )));
+    }
+
+    Ok(((v / 10) << 4) + (v % 10))
 }
 
-pub fn serialize_tag(t: TagType, index: usize, data: &str) -> BytesMut {
-    // TODO: what the hell is capacity 🤔?
-    let mut buf = BytesMut::with_capacity(64);
-    match t {
-        TagType::Regular => buf.put(&b"T"[..]),
-        TagType::Iso => buf.put(&b"I"[..]),
-    };
-    buf.put_u16(dec2bcd(index) as u16);
-    buf.put_u8(0);
-    buf.put_u16(dec2bcd(data.len()) as u16);
+pub(crate) fn encode_bcd_x4(v: u16) -> Result<[u8; 2], Error> {
+    if v > 9999 {
+        return Err(Error::Bounds(format!(
+            "u16 '{}' contains more than 4 digits",
+            v
+        )));
+    }
+
+    let _0 = (v % 10) as u8;
+    let _1 = ((v / 10) % 10) as u8;
+    let _2 = ((v / 100) % 10) as u8;
+    let _3 = ((v / 1000) % 10) as u8;
+
+    let l = (_3 << 4) + _2;
+    let r = (_1 << 4) + _0;
+
+    Ok([l, r])
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Tag {
+    Regular(u16),
+    Iso(u16),
+    IsoSubfield(u16, u8),
+}
+
+impl Tag {
+    pub fn encode_to_buf<B: BufMut>(&self, buf: &mut B) -> Result<(), Error> {
+        match self {
+            Self::Regular(i) => {
+                buf.put(&b"T"[..]);
+                buf.put(&encode_bcd_x4(*i)?[..]);
+                buf.put_u8(0);
+            }
+            Self::Iso(i) => {
+                buf.put(&b"I"[..]);
+                buf.put(&encode_bcd_x4(*i)?[..]);
+                buf.put_u8(0);
+            }
+            Self::IsoSubfield(i, si) => {
+                buf.put(&b"S"[..]);
+                buf.put(&encode_bcd_x4(*i)?[..]);
+                buf.put_u8(encode_bcd_x2(*si)?);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn decode(data: Bytes) -> Result<Self, Error> {
+        if data.len() < 4 {
+            return Err(Error::IncorrectTag("Should be 5 bytes long".into()));
+        }
+        let i = decode_bcd_x4(&[data[1], data[2]])?;
+        let si = decode_bcd_x2(data[3])?;
+        match data[0] {
+            b'T' => Ok(Tag::Regular(i)),
+            b'i' => Ok(Tag::Iso(i)),
+            b'S' => Ok(Tag::IsoSubfield(i, si)),
+            _ => Err(Error::IncorrectTag("Unknown kind".to_string())),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn to_string(&self) -> String {
+        match self {
+            Tag::Regular(i) => {
+                format!("T{:04}", i)
+            }
+            Tag::Iso(i) => {
+                format!("i{:03}", i)
+            }
+            Tag::IsoSubfield(i, si) => {
+                format!("S{:04}{:02}", i, si)
+            }
+        }
+    }
+
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        let bytes = s.as_bytes();
+        match (bytes.get(0), s.len()) {
+            (Some(b'T'), 5) => {
+                let v = parse_ascii_bytes!(
+                    &bytes[1..5],
+                    u16,
+                    Error::IncorrectTag("incorrect format for T".into())
+                )?;
+                Ok(Self::Regular(v))
+            }
+            (Some(b'i'), 4) => {
+                let v = parse_ascii_bytes!(
+                    &bytes[1..4],
+                    u16,
+                    Error::IncorrectTag("incorrect format for i".into())
+                )?;
+                Ok(Self::Iso(v))
+            }
+            (Some(b'S'), 7) => {
+                let v = parse_ascii_bytes!(
+                    &bytes[1..5],
+                    u16,
+                    Error::IncorrectTag("incorrect format for S".into())
+                )?;
+                let sv = parse_ascii_bytes!(
+                    &bytes[5..7],
+                    u8,
+                    Error::IncorrectTag("incorrect format for S".into())
+                )?;
+                Ok(Self::IsoSubfield(v, sv))
+            }
+            (None, _) => return Err(Error::IncorrectTag(format!("Empty"))),
+            (Some(c), l) => {
+                return Err(Error::IncorrectTag(format!(
+                    "Starts with: '{}', length: {}",
+                    c, l
+                )))
+            }
+        }
+    }
+}
+
+pub fn encode_field_to_buf<B: BufMut>(tag: Tag, data: &str, buf: &mut B) -> Result<(), Error> {
+    tag.encode_to_buf(buf)?;
+    buf.put(&encode_bcd_x4(data.len() as u16)?[..]);
     buf.put(data.as_bytes());
-
-    buf.split()
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use bytes::BytesMut;
+
     use super::*;
 
     #[test]
-    fn test_bcd2u16() {
-        assert_eq!(bcd2u16(b"\x00\x01"), 1);
-        assert_eq!(bcd2u16(b"\x00\x02"), 2);
-        assert_eq!(bcd2u16(b"\x00\x03"), 3);
-        assert_eq!(bcd2u16(b"\x00\x04"), 4);
-        assert_eq!(bcd2u16(b"\x00\x05"), 5);
-        assert_eq!(bcd2u16(b"\x00\x06"), 6);
-        assert_eq!(bcd2u16(b"\x00\x07"), 7);
-        assert_eq!(bcd2u16(b"\x00\x08"), 8);
-        assert_eq!(bcd2u16(b"\x00\x09"), 9);
-        assert_eq!(bcd2u16(b"\x00\x10"), 10);
-        assert_eq!(bcd2u16(b"\x00\x11"), 11);
-        assert_eq!(bcd2u16(b"\x00\x12"), 12);
-        assert_eq!(bcd2u16(b"\x00\x13"), 13);
-        assert_eq!(bcd2u16(b"\x00\x14"), 14);
-        assert_eq!(bcd2u16(b"\x00\x15"), 15);
-        assert_eq!(bcd2u16(b"\x00\x16"), 16);
-        assert_eq!(bcd2u16(b"\x00\x17"), 17);
-        assert_eq!(bcd2u16(b"\x00\x18"), 18);
-        assert_eq!(bcd2u16(b"\x00\x19"), 19);
-        assert_eq!(bcd2u16(b"\x00\x20"), 20);
-        assert_eq!(bcd2u16(b"\x00\x21"), 21);
-        assert_eq!(bcd2u16(b"\x00\x22"), 22);
-        assert_eq!(bcd2u16(b"\x00\x23"), 23);
-        assert_eq!(bcd2u16(b"\x00\x24"), 24);
-        assert_eq!(bcd2u16(b"\x00\x25"), 25);
-        assert_eq!(bcd2u16(b"\x00\x26"), 26);
-        assert_eq!(bcd2u16(b"\x00\x27"), 27);
-        assert_eq!(bcd2u16(b"\x00\x28"), 28);
-        assert_eq!(bcd2u16(b"\x00\x29"), 29);
-        assert_eq!(bcd2u16(b"\x00\x30"), 30);
-        assert_eq!(bcd2u16(b"\x00\x32"), 32);
-        assert_eq!(bcd2u16(b"\x00\x43"), 43);
-        assert_eq!(bcd2u16(b"\x00\x54"), 54);
-        assert_eq!(bcd2u16(b"\x00\x65"), 65);
-        assert_eq!(bcd2u16(b"\x00\x76"), 76);
-        assert_eq!(bcd2u16(b"\x00\x87"), 87);
-        assert_eq!(bcd2u16(b"\x00\x99"), 99);
-        assert_eq!(bcd2u16(b"\x01\x05"), 105);
-        assert_eq!(bcd2u16(b"\x01\x37"), 137);
-        assert_eq!(bcd2u16(b"\x02\x93"), 293);
-        assert_eq!(bcd2u16(b"\x03\x60"), 360);
-        assert_eq!(bcd2u16(b"\x12\x34"), 1234);
-        assert_eq!(bcd2u16(b"\x56\x78"), 5678);
-        assert_eq!(bcd2u16(b"\x99\x99"), 9999);
+    fn test_decode_bcd_x4() {
+        assert_eq!(decode_bcd_x4(b"\x00\x01"), Ok(1));
+        assert_eq!(decode_bcd_x4(b"\x00\x02"), Ok(2));
+        assert_eq!(decode_bcd_x4(b"\x00\x03"), Ok(3));
+        assert_eq!(decode_bcd_x4(b"\x00\x04"), Ok(4));
+        assert_eq!(decode_bcd_x4(b"\x00\x05"), Ok(5));
+        assert_eq!(decode_bcd_x4(b"\x00\x06"), Ok(6));
+        assert_eq!(decode_bcd_x4(b"\x00\x07"), Ok(7));
+        assert_eq!(decode_bcd_x4(b"\x00\x08"), Ok(8));
+        assert_eq!(decode_bcd_x4(b"\x00\x09"), Ok(9));
+        assert_eq!(decode_bcd_x4(b"\x00\x10"), Ok(10));
+        assert_eq!(decode_bcd_x4(b"\x00\x11"), Ok(11));
+        assert_eq!(decode_bcd_x4(b"\x00\x12"), Ok(12));
+        assert_eq!(decode_bcd_x4(b"\x00\x13"), Ok(13));
+        assert_eq!(decode_bcd_x4(b"\x00\x14"), Ok(14));
+        assert_eq!(decode_bcd_x4(b"\x00\x15"), Ok(15));
+        assert_eq!(decode_bcd_x4(b"\x00\x16"), Ok(16));
+        assert_eq!(decode_bcd_x4(b"\x00\x17"), Ok(17));
+        assert_eq!(decode_bcd_x4(b"\x00\x18"), Ok(18));
+        assert_eq!(decode_bcd_x4(b"\x00\x19"), Ok(19));
+        assert_eq!(decode_bcd_x4(b"\x00\x20"), Ok(20));
+        assert_eq!(decode_bcd_x4(b"\x00\x21"), Ok(21));
+        assert_eq!(decode_bcd_x4(b"\x00\x22"), Ok(22));
+        assert_eq!(decode_bcd_x4(b"\x00\x23"), Ok(23));
+        assert_eq!(decode_bcd_x4(b"\x00\x24"), Ok(24));
+        assert_eq!(decode_bcd_x4(b"\x00\x25"), Ok(25));
+        assert_eq!(decode_bcd_x4(b"\x00\x26"), Ok(26));
+        assert_eq!(decode_bcd_x4(b"\x00\x27"), Ok(27));
+        assert_eq!(decode_bcd_x4(b"\x00\x28"), Ok(28));
+        assert_eq!(decode_bcd_x4(b"\x00\x29"), Ok(29));
+        assert_eq!(decode_bcd_x4(b"\x00\x30"), Ok(30));
+        assert_eq!(decode_bcd_x4(b"\x00\x32"), Ok(32));
+        assert_eq!(decode_bcd_x4(b"\x00\x43"), Ok(43));
+        assert_eq!(decode_bcd_x4(b"\x00\x54"), Ok(54));
+        assert_eq!(decode_bcd_x4(b"\x00\x65"), Ok(65));
+        assert_eq!(decode_bcd_x4(b"\x00\x76"), Ok(76));
+        assert_eq!(decode_bcd_x4(b"\x00\x87"), Ok(87));
+        assert_eq!(decode_bcd_x4(b"\x00\x99"), Ok(99));
+        assert_eq!(decode_bcd_x4(b"\x01\x05"), Ok(105));
+        assert_eq!(decode_bcd_x4(b"\x01\x37"), Ok(137));
+        assert_eq!(decode_bcd_x4(b"\x02\x93"), Ok(293));
+        assert_eq!(decode_bcd_x4(b"\x03\x60"), Ok(360));
+        assert_eq!(decode_bcd_x4(b"\x12\x34"), Ok(1234));
+        assert_eq!(decode_bcd_x4(b"\x56\x78"), Ok(5678));
+        assert_eq!(decode_bcd_x4(b"\x99\x99"), Ok(9999));
     }
 
     #[test]
-    fn test_dec2bcd() {
-        assert_eq!(dec2bcd(0), 0x0);
-        assert_eq!(dec2bcd(1), 0x1);
-        assert_eq!(dec2bcd(11), 0x11);
-        assert_eq!(dec2bcd(22), 0x22);
-        assert_eq!(dec2bcd(33), 0x33);
-        assert_eq!(dec2bcd(37), 0x37);
-        assert_eq!(dec2bcd(44), 0x44);
-        assert_eq!(dec2bcd(55), 0x55);
-        assert_eq!(dec2bcd(69), 0x69);
-        assert_eq!(dec2bcd(99), 0x99);
-        assert_eq!(dec2bcd(100), 0x100);
-        assert_eq!(dec2bcd(102), 0x0102);
-        assert_eq!(dec2bcd(128), 0x0128);
-        assert_eq!(dec2bcd(129), -1, "BCD 129 is not implemented");
+    fn test_encode_bcd_x2() {
+        assert_eq!(encode_bcd_x2(0), Ok(0x0));
+        assert_eq!(encode_bcd_x2(1), Ok(0x1));
+        assert_eq!(encode_bcd_x2(9), Ok(0x9));
+        assert_eq!(encode_bcd_x2(10), Ok(0x10));
+        assert_eq!(encode_bcd_x2(19), Ok(0x19));
+        assert_eq!(encode_bcd_x2(99), Ok(0x99));
+
+        assert!(encode_bcd_x2(100).is_err());
     }
 
     #[test]
-    fn t0009() {
-        let serialized = serialize_tag(TagType::Regular, 9, "IDDQD");
-        assert_eq!(serialized, b"T\x00\x09\x00\x00\x05IDDQD"[..]);
+    fn test_encode_bcd_x4() {
+        assert_eq!(encode_bcd_x4(0), Ok([0x0, 0x0]));
+        assert_eq!(encode_bcd_x4(1), Ok([0x0, 0x1]));
+        assert_eq!(encode_bcd_x4(9), Ok([0x0, 0x9]));
+        assert_eq!(encode_bcd_x4(10), Ok([0x0, 0x10]));
+        assert_eq!(encode_bcd_x4(19), Ok([0x0, 0x19]));
+        assert_eq!(encode_bcd_x4(100), Ok([0x1, 0x00]));
+        assert_eq!(encode_bcd_x4(101), Ok([0x1, 0x01]));
+        assert_eq!(encode_bcd_x4(119), Ok([0x1, 0x19]));
+        assert_eq!(encode_bcd_x4(1000), Ok([0x10, 0x0]));
+        assert_eq!(encode_bcd_x4(1019), Ok([0x10, 0x19]));
+        assert_eq!(encode_bcd_x4(9999), Ok([0x99, 0x99]));
+
+        assert!(encode_bcd_x4(10000).is_err());
     }
 
     #[test]
-    fn t0022() {
-        let serialized = serialize_tag(TagType::Regular, 22, "XYZ");
-        assert_eq!(serialized, b"T\x00\x22\x00\x00\x03XYZ"[..]);
+    fn encode_tag_regular_09() {
+        let mut buf = BytesMut::new();
+        Tag::Regular(9).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"T\x00\x09\x00"[..]);
     }
 
     #[test]
-    fn t0088() {
-        let serialized = serialize_tag(TagType::Regular, 88, "Lorem ipsum dolor sit amet");
-        assert_eq!(
-            serialized,
-            b"T\x00\x88\x00\x00\x26Lorem ipsum dolor sit amet"[..]
-        );
-    }
-    #[test]
-    fn t0103() {
-        let serialized = serialize_tag(TagType::Regular, 103, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua");
-        assert_eq!(
-                serialized,
-                b"T\x01\x03\x00\x01\x22Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"[..]
-            );
-    }
-    #[test]
-    fn i0037() {
-        let serialized = serialize_tag(TagType::Iso, 37, "716387162837618273");
-        assert_eq!(serialized, b"I\x00\x37\x00\x00\x18716387162837618273"[..]);
+    fn encode_tag_regular_19() {
+        let mut buf = BytesMut::new();
+        Tag::Regular(19).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"T\x00\x19\x00"[..]);
     }
 
     #[test]
-    fn test_msg_len() {
-        assert_eq!(msg_len(1), b"00001"[..]);
-        assert_eq!(msg_len(2), b"00002"[..]);
-        assert_eq!(msg_len(9), b"00009"[..]);
-        assert_eq!(msg_len(25), b"00025"[..]);
-        assert_eq!(msg_len(68), b"00068"[..]);
-        assert_eq!(msg_len(99), b"00099"[..]);
-        assert_eq!(msg_len(101), b"00101"[..]);
-        assert_eq!(msg_len(123), b"00123"[..]);
-        assert_eq!(msg_len(255), b"00255"[..]);
-        assert_eq!(msg_len(256), b"00256"[..]);
-        assert_eq!(msg_len(678), b"00678"[..]);
-        assert_eq!(msg_len(987), b"00987"[..]);
-        assert_eq!(msg_len(1024), b"01024"[..]);
-        assert_eq!(msg_len(2048), b"02048"[..]);
-        assert_eq!(msg_len(4096), b"04096"[..]);
-        assert_eq!(msg_len(9876), b"09876"[..]);
-        assert_eq!(msg_len(10240), b"10240"[..]);
-        assert_eq!(msg_len(98765), b"98765"[..]);
+    fn encode_tag_iso_19() {
+        let mut buf = BytesMut::new();
+        Tag::Iso(19).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"I\x00\x19\x00"[..]);
+    }
+
+    #[test]
+    fn encode_tag_iso_191() {
+        let mut buf = BytesMut::new();
+        Tag::Iso(191).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"I\x01\x91\x00"[..]);
+    }
+
+    #[test]
+    fn encode_tag_subfield_19_2() {
+        let mut buf = BytesMut::new();
+        Tag::IsoSubfield(19, 2).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"S\x00\x19\x02"[..]);
+    }
+
+    #[test]
+    fn encode_tag_subfield_19_22() {
+        let mut buf = BytesMut::new();
+        Tag::IsoSubfield(19, 22).encode_to_buf(&mut buf).unwrap();
+        assert_eq!(buf, b"S\x00\x19\x22"[..]);
+    }
+
+    #[test]
+    fn encode_field() {
+        let mut buf = BytesMut::new();
+        encode_field_to_buf(Tag::Regular(9), "IDDQD", &mut buf).unwrap();
+        assert_eq!(buf, b"T\x00\x09\x00\x00\x05IDDQD"[..]);
+    }
+
+    #[test]
+    fn encode_field_zero() {
+        let mut buf = BytesMut::new();
+        encode_field_to_buf(Tag::Iso(9), "", &mut buf).unwrap();
+        assert_eq!(buf, b"I\x00\x09\x00\x00\x00"[..]);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -110,7 +110,7 @@ impl Tag {
         let si = decode_bcd_x2(data[3])?;
         match data[0] {
             b'T' => Ok(Tag::Regular(i)),
-            b'i' => Ok(Tag::Iso(i)),
+            b'I' => Ok(Tag::Iso(i)),
             b'S' => Ok(Tag::IsoSubfield(i, si)),
             _ => Err(Error::IncorrectTag("Unknown kind".to_string())),
         }
@@ -126,7 +126,7 @@ impl Tag {
                 format!("i{:03}", i)
             }
             Tag::IsoSubfield(i, si) => {
-                format!("S{:04}{:02}", i, si)
+                format!("s{:04}{:02}", i, si)
             }
         }
     }
@@ -134,7 +134,7 @@ impl Tag {
     pub fn from_str(s: &str) -> Result<Self, Error> {
         let bytes = s.as_bytes();
         match (bytes.get(0), s.len()) {
-            (Some(b'T'), 5) => {
+            (Some(b'T'), 5) | (Some(b't'), 5) => {
                 let v = parse_ascii_bytes!(
                     &bytes[1..5],
                     u16,
@@ -142,7 +142,7 @@ impl Tag {
                 )?;
                 Ok(Self::Regular(v))
             }
-            (Some(b'i'), 4) => {
+            (Some(b'I'), 4) | (Some(b'i'), 4) => {
                 let v = parse_ascii_bytes!(
                     &bytes[1..4],
                     u16,
@@ -150,7 +150,7 @@ impl Tag {
                 )?;
                 Ok(Self::Iso(v))
             }
-            (Some(b'S'), 7) => {
+            (Some(b'S'), 7) | (Some(b's'), 7) => {
                 let v = parse_ascii_bytes!(
                     &bytes[1..5],
                     u16,


### PR DESCRIPTION
- Library rewritten so most of methods now return `Error` (previously sometimes error has been just logged and dummy value put in place of erroneous data);
- Added methods to work with fields of `SigmaRequest`/`SigmaRespose` (and constructing them in code);
- Some old methods have been renamed to better reflect what they do.