### PR TITLE
Framed implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2021-12-06
+### Fixed
+- Several clippy-related code style errors.
+### Added
+- Implementations of `Decoder` and `Encoder` traits from `tokio_util::codec` under the `codec` feature.
+
 ## [0.2.2] - 2021-08-27
 ### Changed
 - Used v0.8 of `rand` crate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "extfg-sigma"
 description = "A library for Sigma extfg financial interface messages serialization/deserialization"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Tim Gabets <tim@gabets.ru>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,9 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.23"
+tokio-util = { version = "0.6.9", optional = true, default-features = false, features = ["codec"] }
+
+[features]
+default = []
+
+codec = ["tokio-util"]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,119 @@
+use bytes::{BufMut, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+use crate::{SigmaRequest, SigmaResponse};
+
+/// Ошибка [`Framed`] транспорта с [`SigmaProtocol`].
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    #[error(transparent)]
+    ExtfgSigma(#[from] crate::Error),
+    #[error(transparent)]
+    WrongLenUtf8(#[from] std::str::Utf8Error),
+    #[error(transparent)]
+    WrongLenInt(#[from] std::num::ParseIntError),
+    #[error(transparent)]
+    StdIoError(#[from] std::io::Error),
+}
+
+impl PartialEq for ProtocolError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::StdIoError(self_io), Self::StdIoError(other_io)) => {
+                format!("{:#}", self_io) == format!("{:#}", other_io)
+            }
+            (this, that) => this == that,
+        }
+    }
+}
+
+pub struct SigmaProtocol;
+
+impl Decoder for SigmaProtocol {
+    type Item = SigmaResponse;
+    type Error = ProtocolError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        const LEN_BYTES_COUNT: usize = 5;
+
+        if src.len() < LEN_BYTES_COUNT {
+            return Ok(None);
+        }
+
+        let msg_len = std::str::from_utf8(&src[0..LEN_BYTES_COUNT])
+            .map_err(ProtocolError::from)?
+            .parse::<usize>()
+            .map_err(ProtocolError::from)?;
+
+        let overall_length = msg_len + LEN_BYTES_COUNT;
+
+        Ok(match src.len() < overall_length {
+            true => None,
+            false => Some(SigmaResponse::decode(src.split_to(overall_length).into())?),
+        })
+    }
+}
+
+impl Encoder<SigmaRequest> for SigmaProtocol {
+    type Error = ProtocolError;
+
+    fn encode(&mut self, item: SigmaRequest, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.put(item.encode()?);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_zero() {
+        const DATA: &[u8] = b"";
+        let mut buf = BytesMut::new();
+        buf.put(DATA);
+
+        assert!(matches!(SigmaProtocol.decode(&mut buf), Ok(None)));
+        assert_eq!(buf, DATA);
+    }
+
+    #[test]
+    fn decode_incomplete_length() {
+        const DATA: &[u8] = b"0002";
+        let mut buf = BytesMut::new();
+        buf.put(DATA);
+
+        assert!(matches!(SigmaProtocol.decode(&mut buf), Ok(None)));
+        assert_eq!(buf, DATA);
+    }
+
+    #[test]
+    fn decode_complete_length() {
+        const DATA: &[u8] = b"00024";
+        let mut buf = BytesMut::new();
+        buf.put(DATA);
+
+        assert!(matches!(SigmaProtocol.decode(&mut buf), Ok(None)));
+        assert_eq!(buf, DATA);
+    }
+
+    #[test]
+    fn decode_incomplete_data() {
+        const DATA: &[u8] = b"0002401104007040978T\x00\x31\x00\x00\x0484";
+        let mut buf = BytesMut::new();
+        buf.put(DATA);
+
+        assert!(matches!(SigmaProtocol.decode(&mut buf), Ok(None)));
+        assert_eq!(buf, DATA);
+    }
+
+    #[test]
+    fn decode_complete_data() {
+        const DATA: &[u8] = b"0002401104007040978T\x00\x31\x00\x00\x048495";
+        let mut buf = BytesMut::new();
+        buf.put(DATA);
+
+        assert!(matches!(SigmaProtocol.decode(&mut buf), Ok(Some(_))));
+        assert_eq!(buf, b""[..]);
+    }
+}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -22,7 +22,10 @@ impl PartialEq for ClientProtocolError {
             (Self::StdIoError(self_io), Self::StdIoError(other_io)) => {
                 format!("{:#}", self_io) == format!("{:#}", other_io)
             }
-            (this, that) => this == that,
+            (Self::ExtfgSigma(x), Self::ExtfgSigma(y)) => x == y,
+            (Self::WrongLenUtf8(x), Self::WrongLenUtf8(y)) => x == y,
+            (Self::WrongLenInt(x), Self::WrongLenInt(y)) => x == y,
+            (_,_) => false,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ use crate::util::*;
 #[macro_use]
 mod util;
 
+#[cfg(feature = "codec")]
+mod codec;
+
 #[derive(Debug, thiserror::Error, PartialEq, Clone)]
 pub enum Error {
     #[error("{0}")]


### PR DESCRIPTION
Added implementations of `Decoder` and `Encoder` traits from `tokio_util::codec` under the `codec` feature.

Also fixed several clippy-related errors.