### PR TITLE
`tokio-util` bump to `0.7.3`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2022-07-08
+### Changed
+- Used version `0.7.3` of crate `tokio-util`.
+
 ## [0.3.3] - 2022-04-12
 ### Added
 - `PartialEq` and `Eq` derived implementations for `FeeData`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "extfg-sigma"
 description = "A library for Sigma extfg financial interface messages serialization/deserialization"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Tim Gabets <tim@gabets.ru>"]
 edition = "2018"
 readme = "README.md"
@@ -18,7 +18,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.23"
-tokio-util = { version = "0.6.9", optional = true, default-features = false, features = ["codec"] }
+tokio-util = { version = "0.7.3", optional = true, default-features = false, features = ["codec"] }
 
 [features]
 default = []


### PR DESCRIPTION
Used version `0.7.3` of crate `tokio-util`.